### PR TITLE
Add ability to limit the length of a value target

### DIFF
--- a/streaming_form_data/targets.py
+++ b/streaming_form_data/targets.py
@@ -42,13 +42,23 @@ class NullTarget(BaseTarget):
 
 
 class ValueTarget(BaseTarget):
-    def __init__(self):
+    def __init__(self, max_length=-1):
         super().__init__()
+
+        self._max_length = max_length
+        self._length = 0
 
         self._values = []
 
     def data_received(self, chunk):
+        new_length = self._length + len(chunk)
+
+        if self._max_length > -1 and new_length > self._max_length:
+            raise ValueError(
+                'Value exceeds max length of {}'.format(self._max_length))
+
         self._values.append(chunk)
+        self._length = new_length
 
     @property
     def value(self):

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -51,6 +51,19 @@ class ValueTargetTestCase(TestCase):
         self.assertEqual(target.value, b'')
         self.assertTrue(target.multipart_filename is None)
 
+    def test_exceed_max_length(self):
+        target = ValueTarget(max_length=8)
+
+        target.start()
+
+        target.data_received(b'hello')
+        target.data_received(b' ')
+        with self.assertRaises(ValueError) as context:
+            target.data_received(b'world')
+
+        self.assertEqual(
+            'Value exceeds max length of 8', str(context.exception))
+
 
 class FileTargetTestCase(TestCase):
     def test_basic(self):


### PR DESCRIPTION
added: backwards compatible way to check if a ValueTarget exceeds a
given length. This can help prevent nefarious clients exhausting server
memory by uploading large amounts of data in form value fields.

added: test for max_length exceeded