### PR TITLE
Properly handle the "no file" case with DirectoryTarget

### DIFF
--- a/streaming_form_data/targets.py
+++ b/streaming_form_data/targets.py
@@ -129,6 +129,10 @@ class DirectoryTarget(BaseTarget):
         self.multipart_content_types: List[str] = []
 
     def on_start(self):
+        # Properly handle the case where user does not upload a file
+        if not self.multipart_filename:
+            return
+
         # Path().resolve().name only keeps file name to prevent path traversal
         self.multipart_filename = Path(self.multipart_filename).resolve().name
         self._fd = open(


### PR DESCRIPTION
When using the directory target, if a user chooses to not upload any files, the `multipart_filename` (and `multipart_filenames` list) attributes incorrectly get the name of the current directory - `Path('')` resolves to `PosixPath('.')`, which is of course the current directory. `resolve()` then gives the full path to the current directory, and `name()` gives just the name of the current directory.

This pull request fixes that by leaving `multipart_filename` and `multipart_filenames` unchanged if they are currently empty.