### PR TITLE
Fixed register function target typing

### DIFF
--- a/streaming_form_data/parser.py
+++ b/streaming_form_data/parser.py
@@ -45,7 +45,7 @@ class StreamingFormDataParser:
 
         self._running = False
 
-    def register(self, name: str, target: Type[BaseTarget]):
+    def register(self, name: str, target: BaseTarget):
         if self._running:
             raise ParseFailedException(
                 'Registering parts not allowed while parser is running'


### PR DESCRIPTION
typing.Type is used when you want to indicate that a class or a subclass of that class should be supplied, but that is no that case for this function, because it actually expects an instance of the class/subclass instead of the class itself.

We do `parser.register('name', ValueTarget())`, and not `parser.register('name', ValueTarget)`.