### PR TITLE
Wheel support for cp39 and cp310

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build wheel
         run: python -m cibuildwheel --output-dir dist/
         env:
-          CIBW_BUILD: cp36-* cp37-* cp38-*
+          CIBW_BUILD: cp36-* cp37-* cp38-* cp39-* cp310-*
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Seems support on https://pypi.org/project/streaming-form-data/#files only extends to Python 3.8. Pull request to bring us up to 3.10.