### PR TITLE
Replace flake8 with ruff

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,10 @@ jobs:
           pip-sync requirements.txt
           pip install .
    
+      - name: Lint with ruff
+        run: make lint-ruff
       - name: Lint with black
         run: make lint-black
-      - name: Lint with flake8
-        run: make lint-flake8
       - name: Lint with mypy
         run: make lint-mypy
    

--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,13 @@ fmt-black:
 lint-black:
 	black --check streaming_form_data/*.py tests/ utils/ examples/**/*.py
 
-lint-flake8:
-	flake8 streaming_form_data/*.py tests/ utils/ examples/**/*.py
+lint-ruff:
+	ruff --select=B,C4,C9,E,F,PLC,PLE,PLW,W .
 
 lint-mypy:
 	mypy streaming_form_data/
 
-lint: lint-black lint-flake8 lint-mypy
+lint: lint-ruff lint-black lint-mypy
 
 # test
 

--- a/examples/tornado/stream_request_body.py
+++ b/examples/tornado/stream_request_body.py
@@ -43,7 +43,7 @@ class IndexHandler(RequestHandler):
 def main():
     handlers = [(r'/', IndexHandler), (r'/upload', UploadHandler)]
 
-    settings = dict(debug=True, template_path=os.path.dirname(__file__))
+    settings = {'debug': True, 'template_path': os.path.dirname(__file__)}
 
     app = Application(handlers, **settings)
     app.listen(9999, address='localhost')

--- a/requirements.in
+++ b/requirements.in
@@ -1,8 +1,8 @@
 black==23.3.0
 cython==0.29.34
-flake8==6.0.0
 mypy==1.2.0
 pytest==7.3.1
 requests-toolbelt==0.10.1
+ruff==0.0.262
 twine==4.0.2
 wheel==0.40.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,8 +20,6 @@ docutils==0.19
     # via readme-renderer
 exceptiongroup==1.1.1
     # via pytest
-flake8==6.0.0
-    # via -r requirements.in
 idna==3.4
     # via requests
 importlib-metadata==6.5.1
@@ -36,8 +34,6 @@ keyring==23.13.1
     # via twine
 markdown-it-py==2.2.0
     # via rich
-mccabe==0.7.0
-    # via flake8
 mdurl==0.1.2
     # via markdown-it-py
 more-itertools==9.1.0
@@ -60,10 +56,6 @@ platformdirs==3.2.0
     # via black
 pluggy==1.0.0
     # via pytest
-pycodestyle==2.10.0
-    # via flake8
-pyflakes==3.0.1
-    # via flake8
 pygments==2.15.1
     # via
     #   readme-renderer
@@ -84,6 +76,8 @@ rfc3986==2.0.0
     # via twine
 rich==13.3.4
     # via twine
+ruff==0.0.262
+    # via -r requirements.in
 six==1.16.0
     # via bleach
 tomli==2.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,2 @@
 [metadata]
 license_files = LICENSE.txt
-
-[flake8]
-exclude = .git, .venv, venv
-filename = *.py, *.pyx
-ignore = E203, W503
-per-file-ignores =
-    streaming_form_data/_parser.pyx: E225


### PR DESCRIPTION
% `ruff --select=B,C4,C9,E,F,PLC,PLE,PLW,W .`
```
  "B",    # flake8-bugbear
  "C4",   # flake8-comprehensions
  "C90",  # McCabe cyclomatic complexity
  "E",    # pycodestyle
  "F",    # Pyflakes
  "PLC",  # Pylint conventions
  "PLE",  # Pylint errors
  "PLW",  # Pylint warnings
  "W",    # pycodestyle
```
[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) and can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing (in Rust) tens or hundreds of times faster than any individual tool.

The ruff Action uses minimal steps to run in ~5 seconds, rapidly providing intuitive GitHub Annotations to contributors.

![image](https://user-images.githubusercontent.com/3709715/223758136-afc386d2-70aa-4eff-953a-2c2d82ceea23.png)