### PR TITLE
ci: build wheel for python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,14 +36,11 @@ jobs:
       - uses: actions/setup-python@v3
         with:
           python-version: 3.8
-   
-      - name: Setup pip
-        run: |
-            python -m pip install --upgrade pip
-            python -m pip install cibuildwheel==2.12.3
-    
-      - name: Build wheel
-        run: python -m cibuildwheel --output-dir dist/
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.12.3
+        with:
+          output-dir: dist
         env:
           CIBW_BUILD: cp36-* cp37-* cp38-* cp39-* cp310-*
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           output-dir: dist
         env:
-          CIBW_BUILD: cp36-* cp37-* cp38-* cp39-* cp310-*
+          CIBW_BUILD: cp36-* cp37-* cp38-* cp39-* cp310-* cp311-*
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
           python-version: 3.8
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.3
+        uses: pypa/cibuildwheel@v2.16.5
         with:
           output-dir: dist
         env:


### PR DESCRIPTION
Hi :wave: 

I'm submitting this MR to add python 3.11 wheel builds.

In the README it says the package supports python 3.11 but in fact no wheels are built for this version, so I'm adapting the CI.