### PR TITLE
Add ListTarget and associated test case

### DIFF
--- a/streaming_form_data/targets.py
+++ b/streaming_form_data/targets.py
@@ -85,9 +85,12 @@ class ValueTarget(BaseTarget):
 
 
 class ListTarget(BaseTarget):
-    """ValueTarget stores the input in an in-memory list of bytes.
-    This is useful in case you'd like to have the value contained in an
-    in-memory string.
+    """ListTarget stores the input in an in-memory list of bytes,
+    which is then joined into the final value and appended to an in-memory
+    list of byte strings when each value is finished.
+
+    This is usefull for situations where more than one value may be submitted for
+    the same argument.
     """
 
     def __init__(self, _type=bytes, *args, **kwargs):

--- a/streaming_form_data/targets.py
+++ b/streaming_form_data/targets.py
@@ -82,6 +82,43 @@ class ValueTarget(BaseTarget):
     @property
     def value(self):
         return b"".join(self._values)
+    
+class ListTarget(BaseTarget):
+    """ValueTarget stores the input in an in-memory list of bytes.
+    This is useful in case you'd like to have the value contained in an
+    in-memory string.
+    """
+
+    def __init__(self, _type = bytes, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._temp_value = []
+        self._values = []
+        self._type = _type
+
+    def on_data_received(self, chunk: bytes):
+        self._temp_value.append(chunk)
+
+    def on_finish(self):
+        value = b''.join(self._temp_value)
+        self._temp_value = []
+
+        if self._type == str:
+            value = value.decode('UTF-8')
+        elif self._type == bytes:
+            pass  # already is bytes, no need to do anything
+        else:
+            value = self._type(value)
+
+        self._values.append(value)
+
+    @property
+    def value(self):
+        return self._values
+
+    @property
+    def finished(self):
+        return self._finished
 
 
 class FileTarget(BaseTarget):

--- a/streaming_form_data/targets.py
+++ b/streaming_form_data/targets.py
@@ -83,13 +83,14 @@ class ValueTarget(BaseTarget):
     def value(self):
         return b"".join(self._values)
 
+
 class ListTarget(BaseTarget):
     """ValueTarget stores the input in an in-memory list of bytes.
     This is useful in case you'd like to have the value contained in an
     in-memory string.
     """
 
-    def __init__(self, _type = bytes, *args, **kwargs):
+    def __init__(self, _type=bytes, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         self._temp_value = []
@@ -100,11 +101,11 @@ class ListTarget(BaseTarget):
         self._temp_value.append(chunk)
 
     def on_finish(self):
-        value = b''.join(self._temp_value)
+        value = b"".join(self._temp_value)
         self._temp_value = []
 
         if self._type == str:
-            value = value.decode('UTF-8')
+            value = value.decode("UTF-8")
         elif self._type == bytes:
             pass  # already is bytes, no need to do anything
         else:

--- a/streaming_form_data/targets.py
+++ b/streaming_form_data/targets.py
@@ -82,7 +82,7 @@ class ValueTarget(BaseTarget):
     @property
     def value(self):
         return b"".join(self._values)
-    
+
 class ListTarget(BaseTarget):
     """ValueTarget stores the input in an in-memory list of bytes.
     This is useful in case you'd like to have the value contained in an

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -107,7 +107,7 @@ def test_list_target_basic():
 
 def test_list_target_not_set():
     target=ListTarget()
-    
+
     assert target.multipart_filename is None
     assert target.value == []
 

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -105,7 +105,7 @@ def test_list_target_basic():
     target.finish()
 
     assert target.multipart_filename is None
-    assert target.value == [b"Cat",b"Dog",b"Big Goldfish"]
+    assert target.value == [b"Cat", b"Dog", b"Big Goldfish"]
 
 
 def test_list_target_not_set():

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -11,6 +11,7 @@ from streaming_form_data.targets import (
     DirectoryTarget,
     NullTarget,
     ValueTarget,
+    ListTarget,
     S3Target,
     CSVTarget,
 )
@@ -81,6 +82,34 @@ def test_value_target_total_size_validator():
     with pytest.raises(ValidationError):
         target.data_received(b"world")
 
+
+def test_list_target_basic():
+    target = ListTarget()
+
+    assert target.value == []
+
+    target.multipart_filename = None
+
+    target.start()
+    assert target.multipart_filename is None
+    assert target.value == []
+
+    # Send and finish multiple values
+    target.data_received(b"Cat")
+    target.finish()
+    target.data_received(b"Dog")
+    target.finish()
+    target.data_received(b"Fish")
+    target.finish()
+
+    assert target.multipart_filename is None
+    assert target.value == [b"Cat",b"Dog",b"Fish"]
+
+def test_list_target_not_set():
+    target=ListTarget()
+    
+    assert target.multipart_filename is None
+    assert target.value == []
 
 def test_file_target_basic():
     filename = os.path.join(tempfile.gettempdir(), "file.txt")

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -103,13 +103,15 @@ def test_list_target_basic():
     target.finish()
 
     assert target.multipart_filename is None
-    assert target.value == [b"Cat",b"Dog",b"Fish"]
+    assert target.value == [b"Cat", b"Dog", b"Fish"]
+
 
 def test_list_target_not_set():
-    target=ListTarget()
+    target = ListTarget()
 
     assert target.multipart_filename is None
     assert target.value == []
+
 
 def test_file_target_basic():
     filename = os.path.join(tempfile.gettempdir(), "file.txt")

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -99,11 +99,13 @@ def test_list_target_basic():
     target.finish()
     target.data_received(b"Dog")
     target.finish()
-    target.data_received(b"Fish")
+    target.data_received(b"Big")
+    target.data_received(b" ")
+    target.data_received(b"Goldfish")
     target.finish()
 
     assert target.multipart_filename is None
-    assert target.value == [b"Cat", b"Dog", b"Fish"]
+    assert target.value == [b"Cat",b"Dog",b"Big Goldfish"]
 
 
 def test_list_target_not_set():


### PR DESCRIPTION
Addresses issue #54 by adding a ListTarget target type that compiles multiple values received for the same field into a list, and adds test_list_target_basic and test_list_target_not_set test cases