### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,9 @@ classifiers = [
 keywords = ["cython", "form-data", "forms", "http", "multipart", "streaming", "web"]
 
 [tool.poetry.urls]
-homepage = "https://github.com/siddhantgoel/streaming-form-data"
-repository = "https://github.com/siddhantgoel/streaming-form-data"
-documentation = "https://streaming-form-data.readthedocs.io"
+Homepage = "https://github.com/siddhantgoel/streaming-form-data"
+Repository = "https://github.com/siddhantgoel/streaming-form-data"
+Documentation = "https://streaming-form-data.readthedocs.io"
 
 [tool.poetry.build]
 script = "build.py"


### PR DESCRIPTION
Attempting to install this library with poetry fails. I've opened a PR with more information against poetry-core to fix the underlying issue, but I'm betting that a fix here would get released first.

I think this could also be fixed by changing the [deprecated `tools.poetry.urls` to `project.urls`](https://python-poetry.org/docs/pyproject/#urls), though I haven't tested that version. Feel free to close this if another fix is more appropriate.